### PR TITLE
Add bare bones PKHAddress

### DIFF
--- a/src/main/kotlin/primitives/Network.kt
+++ b/src/main/kotlin/primitives/Network.kt
@@ -1,0 +1,51 @@
+package primitives
+
+enum class NetworkType {
+  MAIN,
+  TEST,
+  REGTEST,
+  UNITTEST
+}
+
+abstract class AddressPrefix {
+  abstract var prefix: Byte
+
+  abstract fun getNetworkType(): NetworkType
+
+  companion object {
+    // FIXME: use map
+    private val pubKeyHashMainAddressPrefix = PubKeyHashMainAddressPrefix()
+    private val pubKeyHashTestAddressPrefix = PubKeyHashTestAddressPrefix()
+
+    fun getAddressPrefix(prefix: Byte): AddressPrefix =
+        when (prefix) {
+          pubKeyHashMainAddressPrefix.prefix -> pubKeyHashMainAddressPrefix
+          pubKeyHashTestAddressPrefix.prefix -> pubKeyHashTestAddressPrefix
+          else -> throw AddressFormatException.InvalidPrefix("No network found for $prefix")
+        }
+
+    fun getAddressPrefix(networkType: NetworkType): AddressPrefix =
+        when (networkType) {
+          NetworkType.MAIN -> pubKeyHashMainAddressPrefix
+          NetworkType.TEST -> pubKeyHashTestAddressPrefix
+          else -> throw AddressFormatException.InvalidPrefix("No network found for $networkType")
+        }
+  }
+}
+
+// TODO: rename?
+class PubKeyHashMainAddressPrefix : AddressPrefix() {
+  override var prefix = 0.toByte()
+
+  override fun getNetworkType(): NetworkType {
+    return NetworkType.MAIN
+  }
+}
+
+class PubKeyHashTestAddressPrefix : AddressPrefix() {
+  override var prefix = 111.toByte()
+
+  override fun getNetworkType(): NetworkType {
+    return NetworkType.TEST
+  }
+}

--- a/src/main/kotlin/primitives/PKHAddress.kt
+++ b/src/main/kotlin/primitives/PKHAddress.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright by the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package primitives
+
+import utilities.Base58
+import java.util.Arrays
+import kotlin.experimental.and
+
+// Code forked from bitcoinj Address.java and modified
+class PKHAddress {
+  val networkType: NetworkType
+  val addressPrefix: AddressPrefix
+
+  private val hash160: ByteArray
+
+  private constructor(networkType: NetworkType, hash160: ByteArray) {
+    this.hash160 = checkNotNull(hash160)
+    if (hash160.size != 20)
+      throw AddressFormatException.InvalidDataLength(
+          "Legacy addresses are 20 byte (160 bit) hashes, but got: ${hash160.size}.")
+
+    this.networkType = networkType
+    this.addressPrefix = AddressPrefix.getAddressPrefix(networkType)
+  }
+
+  fun toBase58(): String {
+    return Base58.encodeChecked(addressPrefix.prefix, hash160)
+  }
+
+  /** The (big endian) 20 byte hash that is the core of a Bitcoin address.  */
+  fun getHash(): ByteArray {
+    return hash160
+  }
+
+  companion object {
+    const val LENGTH = 20
+
+    /**
+     * Construct a {@link LegacyAddress} that represents the given pubkey hash. The resulting
+     * address will be a P2PKH type of address.
+     *
+     * @param params network this address is valid for
+     * @param hash160 20-byte pubkey hash
+     * @return constructed address
+     */
+    fun fromPubKeyHash(network: NetworkType, hash160: ByteArray): PKHAddress {
+      return PKHAddress(network, hash160)
+    }
+
+    /**
+     * Construct a [LegacyAddress] that represents the public part of the given [ECKey].
+     * Note that an address is derived from a hash of the public key and is not the public key
+     * itself.
+     *
+     * @param params network this address is valid for
+     * @param key only the public part is used
+     * @return constructed address
+     */
+    fun fromKey(network: NetworkType, key: ECKey): PKHAddress {
+      return fromPubKeyHash(network, key.pubKeyHash)
+    }
+
+    /**
+     * Construct a [LegacyAddress] from its base58 form.
+     *
+     * @param params expected network this address is valid for, or null if if the network should be
+     * derived from the base58
+     *
+     * @param base58 base58-encoded textual form of the address
+     * @throws AddressFormatException if the given base58 doesn't parse or the checksum is invalid
+     * @throws AddressFormatException.WrongNetwork if the given address is valid but for a different
+     * chain (eg testnet vs mainnet)
+     */
+    // @Throws(AddressFormatException::class, AddressFormatException.WrongNetwork::class)
+    fun fromBase58(network: NetworkType?, base58: String): PKHAddress {
+      // TODO: probably can extract this version and byte
+      val rawBytes = Base58.decodeChecked(base58)
+      val prefix = rawBytes[0] and 0xFF.toByte()
+      // TODO: more kotlin way to copy bytes?
+      val bytes = Arrays.copyOfRange(rawBytes, 1, rawBytes.size)
+
+      // TODO: use kotlin functional map chain
+      val addressPrefix = AddressPrefix.getAddressPrefix(prefix)
+
+      if (network != null && addressPrefix.getNetworkType() != network) {
+        throw AddressFormatException.WrongNetwork(prefix)
+      }
+
+      return PKHAddress(addressPrefix.getNetworkType(), bytes)
+    }
+  }
+}

--- a/src/test/kotlin/primitives/PKHAddressTest.kt
+++ b/src/test/kotlin/primitives/PKHAddressTest.kt
@@ -1,0 +1,52 @@
+package primitives
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import utilities.HEX
+
+class PKHAddressTest {
+  @Test
+  fun `toBase58`() {
+    val a = PKHAddress.fromPubKeyHash(NetworkType.TEST,
+        HEX.decode("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc"))
+    assertThat(a.toBase58()).isEqualTo("n4eA2nbYqErp7H6jebchxAN59DmNpksexv")
+
+    val b = PKHAddress.fromPubKeyHash(NetworkType.MAIN,
+        HEX.decode("4a22c3c4cbb31e4d03b15550636762bda0baf85a"))
+    assertThat(b.toBase58()).isEqualTo("17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL")
+  }
+
+  @Test
+  fun decoding() {
+    val a = PKHAddress.fromBase58(NetworkType.TEST, "n4eA2nbYqErp7H6jebchxAN59DmNpksexv")
+    assertThat(HEX.encode(a.getHash())).isEqualTo("fda79a24e50ff70ff42f7d89585da5bd19d9e5cc")
+
+    val b = PKHAddress.fromBase58(NetworkType.MAIN, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL")
+    assertThat(HEX.encode(b.getHash())).isEqualTo("4a22c3c4cbb31e4d03b15550636762bda0baf85a")
+  }
+
+  @Test
+  fun `throws invalid character exception`() {
+    assertThatThrownBy {
+      PKHAddress.fromBase58(NetworkType.TEST, "this is not a valid address!")
+    }.isInstanceOf(AddressFormatException.InvalidCharacter::class.java)
+        .hasMessage("Invalid character   at position 4")
+  }
+
+  @Test
+  fun `throws invalid data length exception`() {
+    assertThatThrownBy {
+      PKHAddress.fromBase58(NetworkType.TEST, "")
+    }.isInstanceOf(AddressFormatException.InvalidDataLength::class.java)
+        .hasMessage("Input too short: 0")
+  }
+
+  @Test
+  fun `throws wrong network exception`() {
+    assertThatThrownBy {
+      PKHAddress.fromBase58(NetworkType.TEST, "17kzeh4N8g49GFvdDzSf8PjaPfyoD1MndL")
+    }.isInstanceOf(AddressFormatException.WrongNetwork::class.java)
+        .hasMessage("Address prefix did not match acceptable versions for network: 0")
+  }
+}


### PR DESCRIPTION
Starter project for a PubKey Hash address. This was to help inform
the design of the various address types.